### PR TITLE
fix: docker assets/ 404

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,8 @@
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/rust:latest",
 	"features": {
-		"ghcr.io/devcontainers/features/node:latest": {}
+		"ghcr.io/devcontainers/features/node:latest": {},
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
 	},
 	// Use 'mounts' to make the cargo cache persistent in a Docker Volume.
 	// "mounts": [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stoic-quotes"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 authors = ["Jose Storopoli <jose@storopoli.io>"]
 description = "Stoic quotes API backend"

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ WORKDIR /usr/src/app
 
 # Add labels for OCI annotations
 LABEL org.opencontainers.image.source="https://github.com/storopoli/stoic-quotes" \
-      org.opencontainers.image.description="Stoic Quotes" \
-      org.opencontainers.image.licenses="MIT"
+    org.opencontainers.image.description="Stoic Quotes" \
+    org.opencontainers.image.licenses="MIT"
 
 # Copy project's Cargo.toml file
 COPY ./Cargo.toml ./
@@ -37,8 +37,12 @@ RUN cargo build --release --target x86_64-unknown-linux-musl
 # Start a new stage from a slim version of Debian to reduce the size of the final image
 FROM debian:buster-slim
 
+WORKDIR /usr/src/app
+
 # Copy the binary from the builder stage to the new stage
 COPY --from=builder /usr/src/app/target/x86_64-unknown-linux-musl/release/stoic-quotes /usr/local/bin/stoic-quotes
+# Copy the assets/ from the builder stage to the new stage
+COPY --from=builder /usr/src/app/assets /usr/src/app/assets
 
 # Expose port 3000
 EXPOSE 3000


### PR DESCRIPTION
- fix the missing `assets/` dir
- adds `docker-in-docker` to `.devcontainers.json`