### PR TITLE
ci: remove OIDC id-token permission from PR Nix tests

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -27,7 +27,6 @@ jobs:
     name: "${{ matrix.os-name }} Nix Test"
     permissions:
       contents: read
-      id-token: write
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
### Motivation
- Prevent untrusted pull requests from minting GitHub OIDC tokens by removing job-level `id-token: write` while preserving existing Nix PR checks.

### Description
- Removed the `id-token: write` entry from the `config-tests` job `permissions` block in `.github/workflows/nix.yml` so PR-executed builds can no longer request OIDC tokens while still running `nix build -L .` as before.

### Testing
- Verified the workflow file and changes locally using `sed -n '1,220p' .github/workflows/nix.yml`, `nl -ba .github/workflows/nix.yml | sed -n '1,120p'`, and inspected the file diff to confirm the `id-token: write` permission was removed and other steps are unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f62781f9f8833085e9d02e1ab96732)